### PR TITLE
bump mysql-connector version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.33</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>9.1.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Novo Pull Request
Subindo a versão do mysql-connect-j para resolver o apontamento do Dependabot [#2]( https://github.com/Salgado2004/Trabalho-Final-LPOO-UFPR/security/dependabot/2)

- [ ] Requisito funcional
- [ ] Requisito não funcional
- [ ] Testes unitários
- [x] Correção de bugs
- [ ] Documentação

## O que você fez?
This pull request includes an update to the `pom.xml` file to address a dependency change for the MySQL connector. The most important change is the modification of the MySQL connector dependency group and artifact IDs, and its version update.

Dependency updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L38-R40): Changed the MySQL connector dependency from `mysql:mysql-connector-java:8.0.33` to `com.mysql:mysql-connector-j:9.1.0`.
